### PR TITLE
history has emoji instead of text, tighter css

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,4 +1,9 @@
+html {
+    height: 100%;
+}
+
 body {
+    height: 100%;
     background-color: #282c34;
     font-family: 'Montserrat', sans-serif;
     color: whitesmoke;
@@ -77,17 +82,28 @@ section a {
     mask-image: linear-gradient(180deg, #000 60%, transparent);
     display: flex;
     flex-direction: column;
-    height: 800px;
+    height: 70vh;
     overflow: hidden;
 }
 
 .message {
     display: flex;
     justify-content: flex-end;
+    position: relative;
+    margin: 0 30px 10px 0;
+}
+
+.message .emoji {
+    position: absolute;
+    top: 0;
+    right: 40px;
+    margin: 0;
+    font-size: 30px;
 }
 
 .message img {
     width: 50px;
     height: 50px;
     margin-left: 50px;
+    border-radius: 25px;
 }

--- a/src/ChatMessage.tsx
+++ b/src/ChatMessage.tsx
@@ -3,12 +3,35 @@ interface Props {
     avatar: string;
 };
 
+const emoji: { [key: string]: string } = {
+    astonished: "😲",
+    boo: "👎",
+    cheer: "🎉",
+    clap: "👏",
+    cry: "😢",
+    drum: "🥁",
+    airhorn: "📣",
+    punch: "👊",
+    fart: "💨",
+    lame: "🤡",
+    laugh: "😂",
+    rofl: "🤣",
+    lol: "😜",
+    santa: "🎅",
+    quack: "🦆",
+    wolf: "🐺",
+    woof: "🐶",
+    gong: "🟤",
+    shh: "🤫",
+    wow: "🤯",
+};
+
 export const ChatMessage = ({ message, avatar }: Props) => {
     const cmd = message.split(';')[0] ?? 'unknown';
 
     return (<>
         <div className="message">
-            <p>{cmd}</p>
+            <span className="emoji">{emoji[cmd]}</span>
             <img src={avatar} alt="Avatar" />
         </div>
     </>);


### PR DESCRIPTION
History displays an emoji on top of a rounded avatar instead of text next to a square avatar.

Also used a relative height for history and made sure the body's background colour extended to the bottom of the page.

The emoji text mapping is hard coded and doesn't support images (gong and wow are emojis, for now).

<img width="244" alt="image" src="https://user-images.githubusercontent.com/733706/221369530-a6c8475d-0b14-4c14-b594-3aa3a4364fe8.png">
